### PR TITLE
chore: enhance CI with coverage, caching, concurrency, and build-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
@@ -22,14 +26,28 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
 
-      - name: Install package and test dependencies
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[test]"
+          pip install -e ".[dev]"
 
-      - name: Run tests
-        run: pytest tests/ -v --tb=short
+      - name: Run tests with coverage
+        run: |
+          pytest tests/ -v --tb=short \
+            --cov=src \
+            --cov-report=xml \
+            --cov-report=term-missing \
+            --cov-fail-under=70
+
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          flags: unittests
+          fail_ci_if_error: false
 
   lint:
     name: Lint
@@ -41,14 +59,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: "pip"
 
-      - name: Install lint dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ruff
+      - name: Install ruff
+        run: pip install "ruff>=0.4.0"
 
-      - name: Run ruff
+      - name: Run ruff check
         run: ruff check src/ tests/
+
+      - name: Run ruff format check
+        run: ruff format --check src/ tests/
 
   typecheck:
     name: Type Check
@@ -60,11 +80,36 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: "pip"
 
-      - name: Install type-check dependencies
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[typecheck]"
+          pip install -e ".[dev]"
 
       - name: Run mypy
-        run: mypy src/enterprise_rag_patterns/
+        run: mypy src/
+
+  build-check:
+    name: Build Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install build tools
+        run: pip install build twine
+
+      - name: Build distribution
+        run: python -m build
+
+      - name: Check distribution
+        run: twine check dist/*
+
+      - name: Verify installable
+        run: pip install dist/*.whl --force-reinstall

--- a/src/enterprise_rag_patterns/compliance.py
+++ b/src/enterprise_rag_patterns/compliance.py
@@ -43,12 +43,13 @@ class RecordCategory(Enum):
     (protected records) and directory information that institutions may
     disclose without consent if the student has not opted out.
     """
-    DIRECTORY_INFORMATION = "directory_information"    # Name, enrollment status, major — disclosable
-    ACADEMIC_RECORD = "academic_record"                # Grades, transcripts — protected
-    FINANCIAL_RECORD = "financial_record"              # Financial aid, billing — protected
-    DISCIPLINARY_RECORD = "disciplinary_record"        # Conduct records — protected
-    HEALTH_RECORD = "health_record"                    # Campus health, accommodations — protected
-    SYSTEM_GENERATED = "system_generated"              # AI-generated context, workflow state
+
+    DIRECTORY_INFORMATION = "directory_information"  # Name, enrollment status, major — disclosable
+    ACADEMIC_RECORD = "academic_record"  # Grades, transcripts — protected
+    FINANCIAL_RECORD = "financial_record"  # Financial aid, billing — protected
+    DISCIPLINARY_RECORD = "disciplinary_record"  # Conduct records — protected
+    HEALTH_RECORD = "health_record"  # Campus health, accommodations — protected
+    SYSTEM_GENERATED = "system_generated"  # AI-generated context, workflow state
 
 
 class DisclosureReason(Enum):
@@ -58,11 +59,12 @@ class DisclosureReason(Enum):
     FERPA allows disclosure without consent under specific conditions.
     Each access to protected records must map to one of these reasons.
     """
-    SCHOOL_OFFICIAL = "school_official"          # § 99.31(a)(1) — legitimate educational interest
-    AUDIT_EVALUATION = "audit_evaluation"        # § 99.31(a)(3) — authorized audit
-    COURT_ORDER = "court_order"                  # § 99.31(a)(9) — judicial order
-    HEALTH_SAFETY = "health_safety"              # § 99.31(a)(10) — emergency
-    SELF_SERVICE = "self_service"                # Student accessing their own records
+
+    SCHOOL_OFFICIAL = "school_official"  # § 99.31(a)(1) — legitimate educational interest
+    AUDIT_EVALUATION = "audit_evaluation"  # § 99.31(a)(3) — authorized audit
+    COURT_ORDER = "court_order"  # § 99.31(a)(9) — judicial order
+    HEALTH_SAFETY = "health_safety"  # § 99.31(a)(10) — emergency
+    SELF_SERVICE = "self_service"  # Student accessing their own records
 
 
 @dataclass(slots=True)
@@ -87,6 +89,7 @@ class StudentIdentityScope:
         consent_on_file: Whether the student has provided written consent
             for disclosures that go beyond the standard exceptions.
     """
+
     student_id: str
     institution_id: str
     requesting_user_id: str
@@ -113,6 +116,7 @@ class AuditRecord:
 
     Reference: 34 CFR § 99.32 — Record of disclosures required
     """
+
     record_id: str
     student_id: str
     institution_id: str
@@ -120,8 +124,8 @@ class AuditRecord:
     categories_accessed: list[RecordCategory]
     disclosure_reason: DisclosureReason
     access_timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
-    workflow_context: str = ""     # Brief description of the workflow or use case
-    retrieval_query_hash: str = "" # SHA-256 of the retrieval query (not the result) for audit traceability
+    workflow_context: str = ""  # Brief description of the workflow or use case
+    retrieval_query_hash: str = ""  # SHA-256 of the retrieval query (not the result) for audit traceability
 
     def to_log_entry(self) -> str:
         """Format a structured log entry suitable for institutional audit systems."""
@@ -180,6 +184,7 @@ class FERPAContextPolicy:
         block_cross_institution: If True (default), documents tagged with a
             different institution_id than scope.institution_id are always blocked.
     """
+
     scope: StudentIdentityScope
     audit_sink: Callable[[AuditRecord], None] | None = None
     block_cross_institution: bool = True
@@ -285,6 +290,7 @@ class FERPAContextPolicy:
 # ---------------------------------------------------------------------------
 # Convenience factory
 # ---------------------------------------------------------------------------
+
 
 def make_enrollment_advisor_policy(
     student_id: str,

--- a/src/enterprise_rag_patterns/integrations/haystack.py
+++ b/src/enterprise_rag_patterns/integrations/haystack.py
@@ -117,8 +117,7 @@ class FERPAHaystackFilter:
             filtered.append(doc)
 
         logger.info(
-            "[FERPA_AUDIT] event=haystack_filter student_id=%s institution_id=%s "
-            "total=%d removed=%d allowed=%d",
+            "[FERPA_AUDIT] event=haystack_filter student_id=%s institution_id=%s total=%d removed=%d allowed=%d",
             student_id,
             institution_id,
             len(documents),

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -1,6 +1,5 @@
 """Tests for enterprise_rag_patterns.compliance — FERPA context governance."""
 
-
 from enterprise_rag_patterns.compliance import (
     AuditRecord,
     DisclosureReason,
@@ -13,6 +12,7 @@ from enterprise_rag_patterns.compliance import (
 # ---------------------------------------------------------------------------
 # StudentIdentityScope
 # ---------------------------------------------------------------------------
+
 
 class TestStudentIdentityScope:
     def test_permits_directory_information_always(self):
@@ -158,6 +158,7 @@ class TestFERPAContextPolicyFilter:
 # FERPAContextPolicy.record_access
 # ---------------------------------------------------------------------------
 
+
 class TestFERPAContextPolicyAudit:
     def test_record_access_returns_audit_record(self):
         policy = _policy()
@@ -172,7 +173,9 @@ class TestFERPAContextPolicyAudit:
     def test_audit_sink_called(self):
         collected = []
         scope = StudentIdentityScope(
-            student_id="S-1", institution_id="inst-a", requesting_user_id="agent",
+            student_id="S-1",
+            institution_id="inst-a",
+            requesting_user_id="agent",
             authorized_categories={RecordCategory.ACADEMIC_RECORD},
         )
         policy = FERPAContextPolicy(scope=scope, audit_sink=collected.append)
@@ -201,16 +204,14 @@ class TestFERPAContextPolicyAudit:
 
     def test_audit_record_id_is_unique(self):
         policy = _policy()
-        ids = {
-            policy.record_access(categories_accessed=[RecordCategory.ACADEMIC_RECORD]).record_id
-            for _ in range(10)
-        }
+        ids = {policy.record_access(categories_accessed=[RecordCategory.ACADEMIC_RECORD]).record_id for _ in range(10)}
         assert len(ids) == 10
 
 
 # ---------------------------------------------------------------------------
 # make_enrollment_advisor_policy factory
 # ---------------------------------------------------------------------------
+
 
 class TestEnrollmentAdvisorFactory:
     def test_creates_policy_with_correct_scope(self):


### PR DESCRIPTION
## Summary

- Adds `concurrency` block to cancel in-progress runs on the same ref
- Enables `pip` caching via `actions/setup-python@v5` `cache: "pip"` parameter
- Replaces bare `pytest` run with coverage-instrumented run (`--cov=src`, `--cov-report=xml`, `--cov-report=term-missing`, `--cov-fail-under=70`)
- Uploads coverage to Codecov on the Python 3.12 matrix leg only
- Upgrades lint job: pins `ruff>=0.4.0`, adds `ruff format --check` step
- Upgrades typecheck job: uses `.[dev]` install, targets `mypy src/` (whole package tree)
- Adds new **Build Check** job: builds sdist+wheel with `build`, validates metadata with `twine check`, and smoke-tests the wheel install

## Test plan

- [ ] All three matrix test legs pass with coverage >= 70%
- [ ] Lint job passes `ruff check` and `ruff format --check`
- [ ] Type check job passes `mypy src/`
- [ ] Build check job produces a valid distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)