### PR TITLE
chore: add OSS automation suite

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ashutoshrana

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "type/dependencies"
+    commit-message:
+      prefix: "chore"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "type/dependencies"
+    commit-message:
+      prefix: "chore"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,26 @@
+"type/feature":
+  - changed-files:
+    - any-glob-to-any-file: "src/**"
+
+"type/test":
+  - changed-files:
+    - any-glob-to-any-file: "tests/**"
+
+"type/docs":
+  - changed-files:
+    - any-glob-to-any-file:
+        - "docs/**"
+        - "*.md"
+        - "CONTRIBUTING.md"
+        - "README.md"
+
+"type/ci":
+  - changed-files:
+    - any-glob-to-any-file: ".github/**"
+
+"type/build":
+  - changed-files:
+    - any-glob-to-any-file:
+        - "pyproject.toml"
+        - "setup.py"
+        - ".pre-commit-config.yaml"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - "type/dependencies"
+  categories:
+    - title: "Breaking Changes"
+      labels:
+        - "breaking-change"
+    - title: "New Features"
+      labels:
+        - "type/feature"
+    - title: "Bug Fixes"
+      labels:
+        - "type/bug"
+    - title: "Documentation"
+      labels:
+        - "type/docs"
+    - title: "Refactoring"
+      labels:
+        - "type/refactor"
+    - title: "Other Changes"
+      labels:
+        - "*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,37 @@
+name: PR Title Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title follows Conventional Commits
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            test
+            chore
+            perf
+            ci
+            build
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the PR title "{title}" didn't match the configured pattern.
+            Please use lowercase for the subject.
+          ignoreLabels: |
+            bot
+            automated

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,37 @@
+name: Mark stale issues and PRs
+
+on:
+  schedule:
+    - cron: "0 0 * * 1"  # Every Monday at midnight UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed in 14 days if no further activity occurs.
+            If this is still relevant, please add a comment or remove the `status/stale` label.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            recent activity. It will be closed in 7 days if no further activity occurs.
+          close-issue-message: >
+            This issue was closed due to inactivity. Feel free to reopen if it's still relevant.
+          close-pr-message: >
+            This pull request was closed due to inactivity. Feel free to reopen if you'd like to continue.
+          days-before-issue-stale: 30
+          days-before-pr-stale: 14
+          days-before-issue-close: 14
+          days-before-pr-close: 7
+          stale-issue-label: "status/stale"
+          stale-pr-label: "status/stale"
+          exempt-issue-labels: "pinned,status/blocked,type/feature"
+          exempt-pr-labels: "pinned,status/blocked"

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,36 @@
+name: Welcome first-time contributors
+
+on:
+  pull_request_target:
+    types: [opened]
+  issues:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Welcome new contributor
+        uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: |
+            Thanks for opening your first issue here!
+
+            To help us triage it quickly, please make sure you've filled out all sections of the issue template.
+
+            While you wait, you might find these resources helpful:
+            - [Documentation](./docs/)
+            - [Contributing Guide](./CONTRIBUTING.md)
+            - [Architecture Decisions](./docs/adr/)
+          pr-message: |
+            Thanks for your first pull request here!
+
+            A maintainer will review it shortly. While you wait:
+            - Make sure all CI checks pass
+            - Check that your PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format (e.g. `feat: add FERPA compliance filter`)
+            - Ensure the PR description explains the problem and approach

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: no-commit-to-branch
+        args: [--branch, main]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        args: [--ignore-missing-imports]
+        additional_dependencies: []

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.2.x   | Yes       |
+| 0.1.x   | No        |
+
+## Reporting a Vulnerability
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+To report a security vulnerability, please use the [GitHub Security Advisory](../../security/advisories/new) feature, or email the maintainer directly.
+
+You should receive a response within 72 hours. If you do not, please follow up to ensure your message was received.
+
+Please include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+## Disclosure Policy
+
+- We will confirm receipt within 72 hours
+- We will provide an initial assessment within 7 days
+- We aim to release a patch within 30 days of confirmed vulnerability
+- We will coordinate with you on the disclosure timeline
+- Credit will be given in the release notes unless you prefer anonymity
+
+## Notes on Scope
+
+This library implements **enterprise RAG patterns** for FERPA-regulated educational environments. The security surface is:
+- Input validation in FERPA compliance filters (student_id, institution_id, pii detection fields)
+- Audit record generation and log output — ensure no PII leaks into log lines
+- Retrieval context boundaries — controls preventing cross-student data leakage in RAG pipelines
+- Optional dependency imports (lazy import safety for LLM client libraries)
+
+This library does **not** manage authentication, network access, or cryptography directly. Integrating applications are responsible for securing LLM API keys, vector store credentials, and user session management.
+
+**FERPA Note:** If you discover a pattern in this library that could enable unauthorized disclosure of education records, treat it as a high-severity vulnerability and report immediately.


### PR DESCRIPTION
## Summary

This PR adds a complete OSS automation suite to standardize contributor experience, dependency management, and repository hygiene.

## Files Added

| File | Purpose |
|------|---------|
| `.github/CODEOWNERS` | Routes all review requests to `@ashutoshrana` automatically |
| `.github/dependabot.yml` | Weekly automated PRs for pip and GitHub Actions dependency updates, labeled `type/dependencies` |
| `.github/release.yml` | Configures GitHub's auto-generated release notes with categorized changelog sections (Breaking Changes, Features, Bugs, Docs, Refactoring) — dependency bumps excluded |
| `.github/labeler.yml` | Label rules: `type/feature` for `src/`, `type/test` for `tests/`, `type/docs` for docs/markdown, `type/ci` for `.github/`, `type/build` for pyproject/setup files |
| `.github/workflows/labeler.yml` | Runs `actions/labeler@v5` on PRs to auto-apply labels from `labeler.yml` |
| `.github/workflows/stale.yml` | Marks issues stale after 30 days, PRs after 14 days; closes after 14/7 additional days respectively. Runs every Monday. |
| `.github/workflows/pr-title-check.yml` | Enforces Conventional Commits format on PR titles (`feat:`, `fix:`, `docs:`, `chore:`, etc.) using `amannn/action-semantic-pull-request@v5` |
| `.github/workflows/welcome.yml` | Greets first-time issue openers and PR authors with repo-specific guidance using `actions/first-interaction@v1` |
| `SECURITY.md` | Vulnerability reporting policy — directs reporters to GitHub Security Advisories; scopes the security surface to FERPA compliance filters, audit log output, and RAG context boundary controls |
| `.pre-commit-config.yaml` | Local dev hooks: ruff linting + formatting, trailing whitespace, YAML/TOML validation, large file check (500KB), no-commit-to-main guard, mypy type checking |

## Why This Matters

- **CODEOWNERS** ensures no PR merges without maintainer review
- **Dependabot** keeps LLM client libraries and GitHub Actions up to date automatically — critical for security in regulated AI pipelines
- **Stale bot** prevents issue tracker bloat
- **PR title check** enforces a consistent commit history, which feeds into `release.yml` changelog generation
- **SECURITY.md** is a GitHub-recognized file that surfaces a "Report a vulnerability" button on the repo — important for a library handling FERPA-regulated data

## Test Plan

- [ ] Merge and confirm labeler workflow triggers on next PR
- [ ] Confirm dependabot PRs appear within the week
- [ ] Open a test PR with a non-conventional title to verify pr-title-check blocks it
- [ ] Verify SECURITY.md appears as the security policy in repo Settings > Security