### PR TITLE
feat: add LangChain FERPA compliance callback handler

### DIFF
--- a/examples/ferpa_langchain_rag.py
+++ b/examples/ferpa_langchain_rag.py
@@ -1,0 +1,248 @@
+"""
+FERPA-Compliant RAG with LangChain
+====================================
+Demonstrates how to use ``FERPAComplianceCallbackHandler`` to enforce
+FERPA identity-scope filtering in a LangChain retrieval-augmented generation
+(RAG) pipeline.
+
+In this example, stub classes replace the real LangChain components so the
+pattern is self-contained and runnable without installing ``langchain-core``.
+To use in production, swap the stubs for real LangChain objects.
+
+Regulatory basis:
+  34 CFR § 99.31(a)(1) — access control (legitimate educational interest)
+  34 CFR § 99.32       — record of disclosures (audit log requirement)
+
+Installation:
+    pip install 'enterprise-rag-patterns[langchain]'
+
+Production usage:
+    from langchain_community.vectorstores import Chroma          # or any vector store
+    from langchain_openai import ChatOpenAI                      # or any LLM
+    from langchain.chains import RetrievalQA
+    from enterprise_rag_patterns.integrations.langchain import (
+        FERPAComplianceCallbackHandler,
+    )
+    from enterprise_rag_patterns.compliance import (
+        DisclosureReason,
+        RecordCategory,
+        StudentIdentityScope,
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+# ---------------------------------------------------------------------------
+# Step 1: Build the FERPA scope for this request.
+#
+# The scope MUST come from the authenticated session — never from the request
+# body or user-supplied input. This ensures the identity boundary is set by
+# your auth layer, not by user-controlled data.
+# ---------------------------------------------------------------------------
+
+from enterprise_rag_patterns.compliance import (  # noqa: E402
+    AuditRecord,
+    DisclosureReason,
+    RecordCategory,
+    StudentIdentityScope,
+)
+from unittest.mock import patch as _patch  # noqa: E402
+
+# Patch the langchain-core availability check so this example runs without
+# the optional SDK installed.  Remove this block in production where
+# langchain-core is in your dependency tree.
+_patch(
+    "enterprise_rag_patterns.integrations.langchain._check_langchain_available"
+).__enter__()
+
+from enterprise_rag_patterns.integrations.langchain import (  # noqa: E402
+    FERPAComplianceCallbackHandler,
+)
+
+# Scope: advisor session scoped to a single student at one institution.
+# FERPA § 99.31(a)(1): school official with legitimate educational interest.
+scope = StudentIdentityScope(
+    student_id="stu_alice",           # from authenticated session token
+    institution_id="univ_strayer",    # from authenticated session token
+    requesting_user_id="advisor_007", # staff or agent ID
+    authorized_categories={
+        RecordCategory.ACADEMIC_RECORD,
+        RecordCategory.DIRECTORY_INFORMATION,
+    },
+    disclosure_reason=DisclosureReason.SCHOOL_OFFICIAL,
+)
+
+# ---------------------------------------------------------------------------
+# Step 2: Wire up an audit sink (34 CFR § 99.32).
+#
+# In production, replace this with a durable, student-accessible log store
+# (e.g., a database table, Cloud Logging, or a compliance SIEM).
+# ---------------------------------------------------------------------------
+
+audit_log: list[AuditRecord] = []
+
+
+def write_audit_record(record: AuditRecord) -> None:
+    """
+    Persist the FERPA 34 CFR § 99.32 disclosure record.
+
+    In production: insert into a durable audit database.
+    """
+    audit_log.append(record)
+    print(f"[AUDIT] {record.to_log_entry()}")
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Create the callback handler.
+#
+# Pass ``audit_sink`` to ensure every retrieval is logged per § 99.32.
+# Leave ``raise_on_violation=False`` (default) to silently drop unauthorized
+# documents rather than raising an error (preferred for production).
+# ---------------------------------------------------------------------------
+
+handler = FERPAComplianceCallbackHandler(
+    scope=scope,
+    audit_sink=write_audit_record,
+    raise_on_violation=False,  # Change to True in strict-enforcement environments
+)
+
+# ---------------------------------------------------------------------------
+# Step 4: Stub retriever — replace with real vector store retriever.
+#
+# In production:
+#   retriever = chroma_store.as_retriever(callbacks=[handler])
+#   # or
+#   retriever = pinecone_store.as_retriever(callbacks=[handler])
+# ---------------------------------------------------------------------------
+
+
+class _MockDocument:
+    """Stub for langchain_core.documents.Document."""
+
+    def __init__(self, page_content: str, metadata: dict[str, Any]) -> None:
+        self.page_content = page_content
+        self.metadata = metadata
+
+    def __repr__(self) -> str:
+        return f"Document(content={self.page_content!r}, meta={self.metadata})"
+
+
+class _MockRetriever:
+    """
+    Stub retriever that simulates a multi-tenant vector store returning
+    documents for multiple students. The FERPA handler filters these down
+    to only the documents authorized for the current session scope.
+    """
+
+    def __init__(self, documents: list[_MockDocument]) -> None:
+        self._documents = documents
+        self.callbacks: list[Any] = []
+
+    def as_retriever(self, callbacks: list[Any] | None = None) -> "_MockRetriever":
+        self.callbacks = callbacks or []
+        return self
+
+    def invoke(self, query: str) -> list[_MockDocument]:
+        """Simulate retrieval: return all docs, then apply callbacks."""
+        # Simulate the raw vector search result (unfiltered)
+        docs = list(self._documents)
+        print(f"\n[RETRIEVER] Raw results for query={query!r}: {len(docs)} documents")
+
+        # Apply callbacks (the FERPA handler filters in-place on_retriever_end)
+        for cb in self.callbacks:
+            if hasattr(cb, "on_retriever_end"):
+                cb.on_retriever_end(docs, workflow_context="enrollment_advisor_rag")
+
+        print(f"[RETRIEVER] After FERPA filter: {len(docs)} documents")
+        return docs
+
+
+# Build a mock document store simulating a shared multi-tenant vector index.
+# In a real deployment this might be a Chroma, Pinecone, or pgvector collection.
+mock_documents = [
+    # Alice's authorized records at Strayer
+    _MockDocument(
+        "Alice enrolled in Cloud Architecture Spring 2026. GPA: 3.8",
+        {"student_id": "stu_alice", "institution_id": "univ_strayer", "category": "academic_record"},
+    ),
+    _MockDocument(
+        "Alice Smith — enrolled, Computer Science, Class of 2027",
+        {"student_id": "stu_alice", "institution_id": "univ_strayer", "category": "directory_information"},
+    ),
+    # Alice's health record — NOT authorized (health_record not in scope.authorized_categories)
+    _MockDocument(
+        "Alice Smith — campus health visit, 2026-01-10",
+        {"student_id": "stu_alice", "institution_id": "univ_strayer", "category": "health_record"},
+    ),
+    # Bob's record — CROSS-STUDENT leak, must be blocked
+    _MockDocument(
+        "Bob Jones — academic probation notice",
+        {"student_id": "stu_bob", "institution_id": "univ_strayer", "category": "academic_record"},
+    ),
+    # Cross-institution record — must be blocked
+    _MockDocument(
+        "Alice Smith enrollment record at Capella University",
+        {"student_id": "stu_alice", "institution_id": "univ_capella", "category": "academic_record"},
+    ),
+    # General knowledge base (no FERPA metadata) — always passes through
+    _MockDocument(
+        "Enrollment deadlines for Spring 2026: registration closes Feb 15.",
+        {},
+    ),
+]
+
+retriever = _MockRetriever(mock_documents).as_retriever(callbacks=[handler])
+
+# ---------------------------------------------------------------------------
+# Step 5: Run the retrieval chain.
+#
+# In production, this is called inside a LangChain RetrievalQA chain or
+# similar construct. The FERPA handler fires on_retriever_end automatically.
+# ---------------------------------------------------------------------------
+
+query = "What courses is Alice enrolled in and what is her GPA?"
+filtered_docs = retriever.invoke(query)
+
+print("\n--- Authorized documents delivered to LLM context ---")
+for i, doc in enumerate(filtered_docs, 1):
+    print(f"  {i}. {doc.page_content[:80]}...")
+
+print("\n--- Audit log (34 CFR § 99.32 compliance) ---")
+for record in audit_log:
+    print(f"  - record_id={record.record_id}")
+    print(f"    student={record.student_id}, institution={record.institution_id}")
+    print(f"    categories={[c.value for c in record.categories_accessed]}")
+    print(f"    reason={record.disclosure_reason.value}")
+
+# ---------------------------------------------------------------------------
+# Expected output:
+#
+#   [RETRIEVER] Raw results for query=...: 6 documents
+#   [RETRIEVER] After FERPA filter: 3 documents
+#
+#   Authorized documents:
+#     1. Alice enrolled in Cloud Architecture Spring 2026. GPA: 3.8
+#     2. Alice Smith — enrolled, Computer Science, Class of 2027
+#     3. Enrollment deadlines for Spring 2026: registration closes Feb 15.
+#
+#   Blocked (silently dropped):
+#     - Alice's health_record (unauthorized category)
+#     - Bob Jones's record (cross-student)
+#     - Alice's Capella record (cross-institution)
+#
+# In production, pass `filtered_docs` as context to your LLM:
+#
+#   context = "\n\n".join(doc.page_content for doc in filtered_docs)
+#   llm_response = llm.invoke(
+#       f"Context:\n{context}\n\nQuestion: {query}"
+#   )
+# ---------------------------------------------------------------------------
+
+assert len(filtered_docs) == 3, f"Expected 3 authorized docs, got {len(filtered_docs)}"
+assert len(audit_log) == 1, f"Expected 1 audit record, got {len(audit_log)}"
+print("\nAll assertions passed — FERPA filtering working correctly.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,11 +52,12 @@ lint = ["ruff>=0.4.0"]
 typecheck = ["mypy>=1.0"]
 llama-index = ["llama-index-core>=0.10.0"]
 haystack = ["haystack-ai>=2.0.0"]
+langchain = ["langchain-core>=0.3.0"]
 pinecone = ["pinecone>=3.0.0"]
 weaviate = ["weaviate-client>=4.0.0"]
 qdrant = ["qdrant-client>=1.9.0"]
 chromadb = ["chromadb>=0.5.0"]
-all = ["enterprise-rag-patterns[llama-index,haystack,pinecone,weaviate,qdrant,chromadb]"]
+all = ["enterprise-rag-patterns[llama-index,haystack,langchain,pinecone,weaviate,qdrant,chromadb]"]
 dev = [
   "enterprise-rag-patterns[test,lint,typecheck]",
 ]

--- a/src/enterprise_rag_patterns/compliance.py
+++ b/src/enterprise_rag_patterns/compliance.py
@@ -43,12 +43,13 @@ class RecordCategory(Enum):
     (protected records) and directory information that institutions may
     disclose without consent if the student has not opted out.
     """
-    DIRECTORY_INFORMATION = "directory_information"    # Name, enrollment status, major — disclosable
-    ACADEMIC_RECORD = "academic_record"                # Grades, transcripts — protected
-    FINANCIAL_RECORD = "financial_record"              # Financial aid, billing — protected
-    DISCIPLINARY_RECORD = "disciplinary_record"        # Conduct records — protected
-    HEALTH_RECORD = "health_record"                    # Campus health, accommodations — protected
-    SYSTEM_GENERATED = "system_generated"              # AI-generated context, workflow state
+
+    DIRECTORY_INFORMATION = "directory_information"  # Name, enrollment status, major — disclosable
+    ACADEMIC_RECORD = "academic_record"  # Grades, transcripts — protected
+    FINANCIAL_RECORD = "financial_record"  # Financial aid, billing — protected
+    DISCIPLINARY_RECORD = "disciplinary_record"  # Conduct records — protected
+    HEALTH_RECORD = "health_record"  # Campus health, accommodations — protected
+    SYSTEM_GENERATED = "system_generated"  # AI-generated context, workflow state
 
 
 class DisclosureReason(Enum):
@@ -58,11 +59,12 @@ class DisclosureReason(Enum):
     FERPA allows disclosure without consent under specific conditions.
     Each access to protected records must map to one of these reasons.
     """
-    SCHOOL_OFFICIAL = "school_official"          # § 99.31(a)(1) — legitimate educational interest
-    AUDIT_EVALUATION = "audit_evaluation"        # § 99.31(a)(3) — authorized audit
-    COURT_ORDER = "court_order"                  # § 99.31(a)(9) — judicial order
-    HEALTH_SAFETY = "health_safety"              # § 99.31(a)(10) — emergency
-    SELF_SERVICE = "self_service"                # Student accessing their own records
+
+    SCHOOL_OFFICIAL = "school_official"  # § 99.31(a)(1) — legitimate educational interest
+    AUDIT_EVALUATION = "audit_evaluation"  # § 99.31(a)(3) — authorized audit
+    COURT_ORDER = "court_order"  # § 99.31(a)(9) — judicial order
+    HEALTH_SAFETY = "health_safety"  # § 99.31(a)(10) — emergency
+    SELF_SERVICE = "self_service"  # Student accessing their own records
 
 
 @dataclass(slots=True)
@@ -87,6 +89,7 @@ class StudentIdentityScope:
         consent_on_file: Whether the student has provided written consent
             for disclosures that go beyond the standard exceptions.
     """
+
     student_id: str
     institution_id: str
     requesting_user_id: str
@@ -113,6 +116,7 @@ class AuditRecord:
 
     Reference: 34 CFR § 99.32 — Record of disclosures required
     """
+
     record_id: str
     student_id: str
     institution_id: str
@@ -120,8 +124,8 @@ class AuditRecord:
     categories_accessed: list[RecordCategory]
     disclosure_reason: DisclosureReason
     access_timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
-    workflow_context: str = ""     # Brief description of the workflow or use case
-    retrieval_query_hash: str = "" # SHA-256 of the retrieval query (not the result) for audit traceability
+    workflow_context: str = ""  # Brief description of the workflow or use case
+    retrieval_query_hash: str = ""  # SHA-256 of the retrieval query (not the result) for audit traceability
 
     def to_log_entry(self) -> str:
         """Format a structured log entry suitable for institutional audit systems."""
@@ -180,6 +184,7 @@ class FERPAContextPolicy:
         block_cross_institution: If True (default), documents tagged with a
             different institution_id than scope.institution_id are always blocked.
     """
+
     scope: StudentIdentityScope
     audit_sink: Callable[[AuditRecord], None] | None = None
     block_cross_institution: bool = True
@@ -285,6 +290,7 @@ class FERPAContextPolicy:
 # ---------------------------------------------------------------------------
 # Convenience factory
 # ---------------------------------------------------------------------------
+
 
 def make_enrollment_advisor_policy(
     student_id: str,

--- a/src/enterprise_rag_patterns/integrations/__init__.py
+++ b/src/enterprise_rag_patterns/integrations/__init__.py
@@ -7,17 +7,17 @@ installed without any framework dependency.
 
 Available integrations
 ----------------------
-- ``FERPANodePostprocessor`` — LlamaIndex 0.10+ ``BaseNodePostprocessor``
-- ``FERPAHaystackFilter``    — Haystack 2.x ``@component``
-
-LangChain integration is provided via the ``LangChainFERPACallbackHandler``
-in the parent package (see ``enterprise_rag_patterns.compliance``).
+- ``FERPANodePostprocessor``         — LlamaIndex 0.10+ ``BaseNodePostprocessor``
+- ``FERPAHaystackFilter``            — Haystack 2.x ``@component``
+- ``FERPAComplianceCallbackHandler`` — LangChain callback handler (duck-typed)
 """
 
 from .haystack import FERPAHaystackFilter
+from .langchain import FERPAComplianceCallbackHandler
 from .llama_index import FERPANodePostprocessor
 
 __all__ = [
     "FERPANodePostprocessor",
     "FERPAHaystackFilter",
+    "FERPAComplianceCallbackHandler",
 ]

--- a/src/enterprise_rag_patterns/integrations/haystack.py
+++ b/src/enterprise_rag_patterns/integrations/haystack.py
@@ -117,8 +117,7 @@ class FERPAHaystackFilter:
             filtered.append(doc)
 
         logger.info(
-            "[FERPA_AUDIT] event=haystack_filter student_id=%s institution_id=%s "
-            "total=%d removed=%d allowed=%d",
+            "[FERPA_AUDIT] event=haystack_filter student_id=%s institution_id=%s total=%d removed=%d allowed=%d",
             student_id,
             institution_id,
             len(documents),

--- a/src/enterprise_rag_patterns/integrations/langchain.py
+++ b/src/enterprise_rag_patterns/integrations/langchain.py
@@ -1,0 +1,279 @@
+"""
+integrations/langchain.py — LangChain integration for FERPA-compliant RAG pipelines.
+
+Provides ``FERPAComplianceCallbackHandler``, a LangChain ``BaseCallbackHandler``
+(duck-typed, no hard SDK import at class-definition time) that intercepts
+retriever results and applies StudentIdentityScope filtering before the
+documents reach the LLM context window.
+
+Two filtering layers are applied on every ``on_retriever_end`` event:
+  1. **Identity pre-filter** — documents tagged with a different ``student_id``
+     or ``institution_id`` than the authorized scope are removed.
+  2. **Category authorization** — documents whose ``category`` field is not in
+     the scope's ``authorized_categories`` are removed.
+
+Regulatory basis:
+  34 CFR § 99.31(a)(1) — access control (legitimate educational interest)
+  34 CFR § 99.32       — record of disclosures (audit log requirement)
+
+Installation::
+
+    pip install 'enterprise-rag-patterns[langchain]'
+
+Usage::
+
+    from enterprise_rag_patterns.integrations.langchain import (
+        FERPAComplianceCallbackHandler,
+    )
+    from enterprise_rag_patterns.compliance import (
+        DisclosureReason,
+        RecordCategory,
+        StudentIdentityScope,
+    )
+
+    scope = StudentIdentityScope(
+        student_id="stu_001",
+        institution_id="inst_abc",
+        requesting_user_id="advisor_007",
+        authorized_categories={RecordCategory.ACADEMIC_RECORD},
+        disclosure_reason=DisclosureReason.SCHOOL_OFFICIAL,
+    )
+    handler = FERPAComplianceCallbackHandler(scope=scope)
+
+    # Pass handler to a LangChain retriever or chain:
+    retriever = vector_store.as_retriever(callbacks=[handler])
+    docs = retriever.invoke("What is my enrollment status?")
+    # docs contains only stu_001's academic records at inst_abc
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from enterprise_rag_patterns.compliance import (
+    AuditRecord,
+    DisclosureReason,
+    FERPAContextPolicy,
+    RecordCategory,
+    StudentIdentityScope,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _check_langchain_available() -> None:
+    """
+    Verify langchain-core is installed and raise a clear ImportError if not.
+
+    Called lazily at handler instantiation — not at module import — so that
+    the package remains importable without the optional SDK dependency.
+    """
+    try:
+        import langchain_core.callbacks  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "langchain-core is required for the LangChain integration. "
+            "Install it with: pip install 'enterprise-rag-patterns[langchain]'"
+        ) from exc
+
+
+class FERPAComplianceCallbackHandler:
+    """
+    LangChain callback handler that enforces FERPA identity-scope filtering
+    on retriever results before they enter the LLM context window.
+
+    Implements the LangChain ``BaseCallbackHandler`` interface via duck typing
+    so that the class can be defined and imported without ``langchain-core``
+    installed.  The SDK availability check is deferred to ``__init__``.
+
+    Two enforcement layers (matching ``FERPAContextPolicy``):
+      1. Identity pre-filter: ``student_id`` + ``institution_id`` must match scope.
+      2. Category authorization: ``category`` must be in scope's
+         ``authorized_categories``.
+
+    Documents without ``student_id`` / ``institution_id`` metadata are treated
+    as non-FERPA shared knowledge-base content and are passed through unchanged.
+
+    Regulatory basis: 34 CFR § 99.31(a)(1), § 99.32
+
+    Args:
+        scope: ``StudentIdentityScope`` defining the authorized student,
+               institution, and record categories for this request.
+        student_id_field: Document metadata key for the student identifier.
+                          Default: ``"student_id"``
+        institution_id_field: Document metadata key for the institution.
+                              Default: ``"institution_id"``
+        category_field: Document metadata key for the record category.
+                        Default: ``"category"``
+        audit_sink: Optional callable receiving each ``AuditRecord`` produced
+                    by this handler (34 CFR § 99.32).  When ``None``, records
+                    are emitted via ``logging`` only.
+        raise_on_violation: If ``True``, raise ``ValueError`` when unauthorized
+                            documents are detected.  If ``False`` (default),
+                            silently drop unauthorized documents and log a
+                            ``WARNING``.
+    """
+
+    def __init__(
+        self,
+        scope: StudentIdentityScope,
+        student_id_field: str = "student_id",
+        institution_id_field: str = "institution_id",
+        category_field: str = "category",
+        audit_sink: Any | None = None,
+        raise_on_violation: bool = False,
+    ) -> None:
+        _check_langchain_available()
+        self.policy = FERPAContextPolicy(scope=scope, audit_sink=audit_sink)
+        self.student_id_field = student_id_field
+        self.institution_id_field = institution_id_field
+        self.category_field = category_field
+        self.raise_on_violation = raise_on_violation
+
+    # ------------------------------------------------------------------
+    # Core LangChain event handler
+    # ------------------------------------------------------------------
+
+    def on_retriever_end(self, documents: list[Any], **kwargs: Any) -> None:
+        """
+        Intercept retriever results and apply FERPA filtering in-place.
+
+        Called by the LangChain callback system immediately after a retriever
+        returns results.  The ``documents`` list is mutated in-place so that
+        downstream chain components see only the authorized subset.
+
+        FERPA 34 CFR § 99.32: each disclosure must be logged.
+
+        Args:
+            documents: List of LangChain ``Document``-like objects (duck-typed;
+                       must expose a ``.metadata`` dict attribute).
+            **kwargs: Additional LangChain callback keyword arguments
+                      (``run_id``, ``parent_run_id``, etc.).
+        """
+        original_count = len(documents)
+
+        # Convert to the dict-based API expected by FERPAContextPolicy.
+        # Inject "_idx" so we can map filtered results back to original objects.
+        doc_dicts: list[dict[str, Any]] = [
+            self._to_dict(doc, idx) for idx, doc in enumerate(documents)
+        ]
+
+        filtered_dicts = self.policy.filter_retrieved_documents(
+            doc_dicts,
+            student_id_field=self.student_id_field,
+            institution_id_field=self.institution_id_field,
+            # FERPAContextPolicy uses "record_category" as its default field name;
+            # we map our category_field value into "record_category" in _to_dict.
+            category_field="record_category",
+        )
+
+        # Rebuild the filtered document list, preserving the original objects.
+        retained_indices: set[int] = {
+            int(d["_idx"])  # type: ignore[arg-type]
+            for d in filtered_dicts
+            if "_idx" in d
+        }
+        filtered_documents = [
+            doc for idx, doc in enumerate(documents) if idx in retained_indices
+        ]
+
+        removed = original_count - len(filtered_documents)
+
+        if removed > 0 and self.raise_on_violation:
+            raise ValueError(
+                f"FERPA violation: {removed} unauthorized document(s) blocked for "
+                f"student={self.policy.scope.student_id!r}, "
+                f"institution={self.policy.scope.institution_id!r}. "
+                "Check StudentIdentityScope.authorized_categories."
+            )
+
+        # Mutate the list in-place — LangChain passes the same list downstream.
+        documents.clear()
+        documents.extend(filtered_documents)
+
+        # Emit FERPA 34 CFR § 99.32 audit record for any accessed categories.
+        categories_accessed = self._extract_accessed_categories(filtered_documents)
+        if categories_accessed:
+            workflow_ctx = kwargs.get("workflow_context", "langchain_retriever")
+            audit: AuditRecord = self.policy.record_access(
+                categories_accessed=list(categories_accessed),
+                workflow_context=str(workflow_ctx),
+            )
+            logger.info("FERPA audit: %s", audit.to_log_entry())
+
+        if removed > 0:
+            logger.warning(
+                "[FERPA_AUDIT] event=langchain_filter student_id=%s institution_id=%s "
+                "total=%d removed=%d allowed=%d",
+                self.policy.scope.student_id,
+                self.policy.scope.institution_id,
+                original_count,
+                removed,
+                len(filtered_documents),
+            )
+
+    # ------------------------------------------------------------------
+    # No-op handlers for other LangChain callback events
+    # ------------------------------------------------------------------
+
+    def on_llm_start(self, *args: Any, **kwargs: Any) -> None:
+        """No-op: LLM start event."""
+
+    def on_llm_end(self, *args: Any, **kwargs: Any) -> None:
+        """No-op: LLM end event."""
+
+    def on_chain_start(self, *args: Any, **kwargs: Any) -> None:
+        """No-op: chain start event."""
+
+    def on_chain_end(self, *args: Any, **kwargs: Any) -> None:
+        """No-op: chain end event."""
+
+    def on_tool_start(self, *args: Any, **kwargs: Any) -> None:
+        """No-op: tool start event."""
+
+    def on_tool_end(self, *args: Any, **kwargs: Any) -> None:
+        """No-op: tool end event."""
+
+    def on_retriever_start(self, *args: Any, **kwargs: Any) -> None:
+        """No-op: retriever start event."""
+
+    def on_retriever_error(self, *args: Any, **kwargs: Any) -> None:
+        """No-op: retriever error event."""
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _to_dict(self, doc: Any, index: int = 0) -> dict[str, Any]:
+        """
+        Convert a LangChain Document-like object to a dict for FERPAContextPolicy.
+
+        Maps the configured ``category_field`` to ``"record_category"`` (the
+        field name expected by ``FERPAContextPolicy.filter_retrieved_documents``).
+        Injects ``_idx`` so we can recover the original objects after filtering.
+        """
+        meta: dict[str, Any] = getattr(doc, "metadata", {}) or {}
+        d: dict[str, Any] = {"_idx": index}
+        if self.student_id_field in meta:
+            d[self.student_id_field] = meta[self.student_id_field]
+        if self.institution_id_field in meta:
+            d[self.institution_id_field] = meta[self.institution_id_field]
+        if self.category_field in meta:
+            d["record_category"] = meta[self.category_field]
+        return d
+
+    def _extract_accessed_categories(
+        self, documents: list[Any]
+    ) -> set[RecordCategory]:
+        """Return the set of RecordCategory values present in the authorized documents."""
+        categories: set[RecordCategory] = set()
+        for doc in documents:
+            meta: dict[str, Any] = getattr(doc, "metadata", {}) or {}
+            raw = meta.get(self.category_field)
+            if raw is not None:
+                try:
+                    categories.add(RecordCategory(raw))
+                except ValueError:
+                    pass  # Unknown category string — skip
+        return categories

--- a/src/enterprise_rag_patterns/integrations/langchain.py
+++ b/src/enterprise_rag_patterns/integrations/langchain.py
@@ -167,7 +167,7 @@ class FERPAComplianceCallbackHandler:
 
         # Rebuild the filtered document list, preserving the original objects.
         retained_indices: set[int] = {
-            int(d["_idx"])  # type: ignore[arg-type]
+            int(str(d["_idx"]))
             for d in filtered_dicts
             if "_idx" in d
         }

--- a/src/enterprise_rag_patterns/integrations/langchain.py
+++ b/src/enterprise_rag_patterns/integrations/langchain.py
@@ -53,7 +53,6 @@ from typing import Any
 
 from enterprise_rag_patterns.compliance import (
     AuditRecord,
-    DisclosureReason,
     FERPAContextPolicy,
     RecordCategory,
     StudentIdentityScope,
@@ -155,9 +154,7 @@ class FERPAComplianceCallbackHandler:
 
         # Convert to the dict-based API expected by FERPAContextPolicy.
         # Inject "_idx" so we can map filtered results back to original objects.
-        doc_dicts: list[dict[str, Any]] = [
-            self._to_dict(doc, idx) for idx, doc in enumerate(documents)
-        ]
+        doc_dicts: list[dict[str, Any]] = [self._to_dict(doc, idx) for idx, doc in enumerate(documents)]
 
         filtered_dicts = self.policy.filter_retrieved_documents(
             doc_dicts,
@@ -174,9 +171,7 @@ class FERPAComplianceCallbackHandler:
             for d in filtered_dicts
             if "_idx" in d
         }
-        filtered_documents = [
-            doc for idx, doc in enumerate(documents) if idx in retained_indices
-        ]
+        filtered_documents = [doc for idx, doc in enumerate(documents) if idx in retained_indices]
 
         removed = original_count - len(filtered_documents)
 
@@ -204,8 +199,7 @@ class FERPAComplianceCallbackHandler:
 
         if removed > 0:
             logger.warning(
-                "[FERPA_AUDIT] event=langchain_filter student_id=%s institution_id=%s "
-                "total=%d removed=%d allowed=%d",
+                "[FERPA_AUDIT] event=langchain_filter student_id=%s institution_id=%s total=%d removed=%d allowed=%d",
                 self.policy.scope.student_id,
                 self.policy.scope.institution_id,
                 original_count,
@@ -263,9 +257,7 @@ class FERPAComplianceCallbackHandler:
             d["record_category"] = meta[self.category_field]
         return d
 
-    def _extract_accessed_categories(
-        self, documents: list[Any]
-    ) -> set[RecordCategory]:
+    def _extract_accessed_categories(self, documents: list[Any]) -> set[RecordCategory]:
         """Return the set of RecordCategory values present in the authorized documents."""
         categories: set[RecordCategory] = set()
         for doc in documents:

--- a/src/enterprise_rag_patterns/integrations/langchain.py
+++ b/src/enterprise_rag_patterns/integrations/langchain.py
@@ -166,11 +166,7 @@ class FERPAComplianceCallbackHandler:
         )
 
         # Rebuild the filtered document list, preserving the original objects.
-        retained_indices: set[int] = {
-            int(str(d["_idx"]))
-            for d in filtered_dicts
-            if "_idx" in d
-        }
+        retained_indices: set[int] = {int(str(d["_idx"])) for d in filtered_dicts if "_idx" in d}
         filtered_documents = [doc for idx, doc in enumerate(documents) if idx in retained_indices]
 
         removed = original_count - len(filtered_documents)

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -1,6 +1,5 @@
 """Tests for enterprise_rag_patterns.compliance — FERPA context governance."""
 
-
 from enterprise_rag_patterns.compliance import (
     AuditRecord,
     DisclosureReason,
@@ -13,6 +12,7 @@ from enterprise_rag_patterns.compliance import (
 # ---------------------------------------------------------------------------
 # StudentIdentityScope
 # ---------------------------------------------------------------------------
+
 
 class TestStudentIdentityScope:
     def test_permits_directory_information_always(self):
@@ -158,6 +158,7 @@ class TestFERPAContextPolicyFilter:
 # FERPAContextPolicy.record_access
 # ---------------------------------------------------------------------------
 
+
 class TestFERPAContextPolicyAudit:
     def test_record_access_returns_audit_record(self):
         policy = _policy()
@@ -172,7 +173,9 @@ class TestFERPAContextPolicyAudit:
     def test_audit_sink_called(self):
         collected = []
         scope = StudentIdentityScope(
-            student_id="S-1", institution_id="inst-a", requesting_user_id="agent",
+            student_id="S-1",
+            institution_id="inst-a",
+            requesting_user_id="agent",
             authorized_categories={RecordCategory.ACADEMIC_RECORD},
         )
         policy = FERPAContextPolicy(scope=scope, audit_sink=collected.append)
@@ -201,16 +204,14 @@ class TestFERPAContextPolicyAudit:
 
     def test_audit_record_id_is_unique(self):
         policy = _policy()
-        ids = {
-            policy.record_access(categories_accessed=[RecordCategory.ACADEMIC_RECORD]).record_id
-            for _ in range(10)
-        }
+        ids = {policy.record_access(categories_accessed=[RecordCategory.ACADEMIC_RECORD]).record_id for _ in range(10)}
         assert len(ids) == 10
 
 
 # ---------------------------------------------------------------------------
 # make_enrollment_advisor_policy factory
 # ---------------------------------------------------------------------------
+
 
 class TestEnrollmentAdvisorFactory:
     def test_creates_policy_with_correct_scope(self):

--- a/tests/test_langchain_integration.py
+++ b/tests/test_langchain_integration.py
@@ -1,0 +1,342 @@
+"""
+Tests for FERPAComplianceCallbackHandler (LangChain integration).
+
+Uses duck-typed stubs — langchain-core is NOT required to run these tests.
+The handler's lazy import check is bypassed via monkeypatching so we can
+test filtering behaviour without the optional SDK dependency.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from enterprise_rag_patterns.compliance import (
+    AuditRecord,
+    DisclosureReason,
+    RecordCategory,
+    StudentIdentityScope,
+)
+from enterprise_rag_patterns.integrations.langchain import FERPAComplianceCallbackHandler
+
+
+# ---------------------------------------------------------------------------
+# Stub: duck-typed LangChain Document (no SDK needed)
+# ---------------------------------------------------------------------------
+
+
+class MockDocument:
+    """Minimal duck-typed stub for langchain_core.documents.Document."""
+
+    def __init__(self, page_content: str, metadata: dict[str, Any]) -> None:
+        self.page_content = page_content
+        self.metadata = metadata
+
+    def __repr__(self) -> str:
+        return f"MockDocument(metadata={self.metadata!r})"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_scope(
+    student_id: str = "stu_001",
+    institution_id: str = "inst_abc",
+    categories: set[RecordCategory] | None = None,
+) -> StudentIdentityScope:
+    return StudentIdentityScope(
+        student_id=student_id,
+        institution_id=institution_id,
+        requesting_user_id="advisor_007",
+        authorized_categories=categories or {RecordCategory.ACADEMIC_RECORD},
+        disclosure_reason=DisclosureReason.SCHOOL_OFFICIAL,
+    )
+
+
+def _make_handler(
+    scope: StudentIdentityScope | None = None,
+    raise_on_violation: bool = False,
+    audit_sink: Any = None,
+) -> FERPAComplianceCallbackHandler:
+    """Construct handler with langchain-core import check patched out."""
+    with patch(
+        "enterprise_rag_patterns.integrations.langchain._check_langchain_available"
+    ):
+        return FERPAComplianceCallbackHandler(
+            scope=scope or _make_scope(),
+            raise_on_violation=raise_on_violation,
+            audit_sink=audit_sink,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Identity filtering tests
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityFiltering:
+    def test_allows_authorized_documents(self) -> None:
+        handler = _make_handler()
+        docs = [
+            MockDocument(
+                "Grade report",
+                {"student_id": "stu_001", "institution_id": "inst_abc", "category": "academic_record"},
+            ),
+        ]
+        handler.on_retriever_end(docs)
+        assert len(docs) == 1
+
+    def test_blocks_cross_student_documents(self) -> None:
+        handler = _make_handler()
+        docs = [
+            MockDocument("Other student", {"student_id": "stu_999", "institution_id": "inst_abc", "category": "academic_record"}),
+            MockDocument("Own record", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "academic_record"}),
+        ]
+        handler.on_retriever_end(docs)
+        assert len(docs) == 1
+        assert docs[0].metadata["student_id"] == "stu_001"
+
+    def test_blocks_cross_institution_documents(self) -> None:
+        handler = _make_handler()
+        docs = [
+            MockDocument("Other inst", {"student_id": "stu_001", "institution_id": "inst_xyz", "category": "academic_record"}),
+        ]
+        handler.on_retriever_end(docs)
+        assert len(docs) == 0
+
+    def test_shared_knowledge_passes_through(self) -> None:
+        """Documents without student/institution identifiers pass as shared KB content."""
+        handler = _make_handler()
+        docs = [MockDocument("General policy doc", {})]
+        handler.on_retriever_end(docs)
+        assert len(docs) == 1
+
+    def test_empty_document_list(self) -> None:
+        handler = _make_handler()
+        docs: list[MockDocument] = []
+        handler.on_retriever_end(docs)
+        assert len(docs) == 0
+
+    def test_mixed_batch_filters_correctly(self) -> None:
+        handler = _make_handler()
+        docs = [
+            MockDocument("Own", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "academic_record"}),
+            MockDocument("Other student", {"student_id": "stu_002", "institution_id": "inst_abc", "category": "academic_record"}),
+            MockDocument("Other inst", {"student_id": "stu_001", "institution_id": "inst_xyz", "category": "academic_record"}),
+            MockDocument("Shared KB", {}),
+        ]
+        handler.on_retriever_end(docs)
+        # Only own record + shared KB should remain
+        assert len(docs) == 2
+        remaining_students = {d.metadata.get("student_id") for d in docs}
+        assert remaining_students == {"stu_001", None}
+
+
+# ---------------------------------------------------------------------------
+# Category authorization tests
+# ---------------------------------------------------------------------------
+
+
+class TestCategoryFiltering:
+    def test_blocks_unauthorized_category(self) -> None:
+        handler = _make_handler(scope=_make_scope(categories={RecordCategory.ACADEMIC_RECORD}))
+        docs = [
+            MockDocument("Health record", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "health_record"}),
+        ]
+        handler.on_retriever_end(docs)
+        assert len(docs) == 0
+
+    def test_allows_authorized_category(self) -> None:
+        handler = _make_handler(scope=_make_scope(categories={RecordCategory.ACADEMIC_RECORD}))
+        docs = [
+            MockDocument("Transcript", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "academic_record"}),
+        ]
+        handler.on_retriever_end(docs)
+        assert len(docs) == 1
+
+    def test_allows_directory_information_always(self) -> None:
+        """FERPA: directory_information is always permitted regardless of scope."""
+        handler = _make_handler(scope=_make_scope(categories={RecordCategory.ACADEMIC_RECORD}))
+        docs = [
+            MockDocument("Dir info", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "directory_information"}),
+        ]
+        handler.on_retriever_end(docs)
+        assert len(docs) == 1
+
+    def test_blocks_multiple_unauthorized_categories(self) -> None:
+        handler = _make_handler(scope=_make_scope(categories={RecordCategory.ACADEMIC_RECORD}))
+        docs = [
+            MockDocument("Health", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "health_record"}),
+            MockDocument("Disciplinary", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "disciplinary_record"}),
+            MockDocument("Academic", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "academic_record"}),
+        ]
+        handler.on_retriever_end(docs)
+        assert len(docs) == 1
+        assert docs[0].metadata["category"] == "academic_record"
+
+
+# ---------------------------------------------------------------------------
+# raise_on_violation mode
+# ---------------------------------------------------------------------------
+
+
+class TestRaiseOnViolation:
+    def test_raises_when_unauthorized_document_blocked(self) -> None:
+        handler = _make_handler(raise_on_violation=True)
+        docs = [
+            MockDocument("Other student", {"student_id": "stu_999", "institution_id": "inst_abc", "category": "academic_record"}),
+        ]
+        with pytest.raises(ValueError, match="FERPA violation"):
+            handler.on_retriever_end(docs)
+
+    def test_does_not_raise_when_all_authorized(self) -> None:
+        handler = _make_handler(raise_on_violation=True)
+        docs = [
+            MockDocument("Own", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "academic_record"}),
+        ]
+        # Should not raise
+        handler.on_retriever_end(docs)
+        assert len(docs) == 1
+
+    def test_does_not_raise_in_default_mode(self) -> None:
+        handler = _make_handler(raise_on_violation=False)
+        docs = [
+            MockDocument("Other", {"student_id": "stu_999", "institution_id": "inst_abc", "category": "academic_record"}),
+        ]
+        # Should silently drop, not raise
+        handler.on_retriever_end(docs)
+        assert len(docs) == 0
+
+
+# ---------------------------------------------------------------------------
+# Audit sink tests
+# ---------------------------------------------------------------------------
+
+
+class TestAuditSink:
+    def test_audit_sink_receives_record_for_category_access(self) -> None:
+        audit_log: list[AuditRecord] = []
+        handler = _make_handler(audit_sink=audit_log.append)
+        docs = [
+            MockDocument("Transcript", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "academic_record"}),
+        ]
+        handler.on_retriever_end(docs)
+        assert len(audit_log) == 1
+        record = audit_log[0]
+        assert record.student_id == "stu_001"
+        assert record.institution_id == "inst_abc"
+        assert RecordCategory.ACADEMIC_RECORD in record.categories_accessed
+
+    def test_audit_sink_not_called_for_shared_kb_only(self) -> None:
+        """No audit record for docs that have no FERPA category."""
+        audit_log: list[AuditRecord] = []
+        handler = _make_handler(audit_sink=audit_log.append)
+        docs = [MockDocument("Shared policy", {})]
+        handler.on_retriever_end(docs)
+        assert len(audit_log) == 0
+
+    def test_audit_sink_not_called_when_all_filtered(self) -> None:
+        """No audit record when all docs are blocked (nothing actually accessed)."""
+        audit_log: list[AuditRecord] = []
+        handler = _make_handler(audit_sink=audit_log.append)
+        docs = [
+            MockDocument("Other", {"student_id": "stu_999", "institution_id": "inst_abc", "category": "academic_record"}),
+        ]
+        handler.on_retriever_end(docs)
+        assert len(audit_log) == 0
+
+
+# ---------------------------------------------------------------------------
+# No-op handler methods
+# ---------------------------------------------------------------------------
+
+
+class TestNoopHandlers:
+    """All non-retriever callback methods must be callable without raising."""
+
+    def _handler(self) -> FERPAComplianceCallbackHandler:
+        return _make_handler()
+
+    def test_on_llm_start(self) -> None:
+        self._handler().on_llm_start()
+
+    def test_on_llm_end(self) -> None:
+        self._handler().on_llm_end()
+
+    def test_on_chain_start(self) -> None:
+        self._handler().on_chain_start()
+
+    def test_on_chain_end(self) -> None:
+        self._handler().on_chain_end()
+
+    def test_on_tool_start(self) -> None:
+        self._handler().on_tool_start()
+
+    def test_on_tool_end(self) -> None:
+        self._handler().on_tool_end()
+
+    def test_on_retriever_start(self) -> None:
+        self._handler().on_retriever_start()
+
+    def test_on_retriever_error(self) -> None:
+        self._handler().on_retriever_error()
+
+
+# ---------------------------------------------------------------------------
+# Custom field name configuration
+# ---------------------------------------------------------------------------
+
+
+class TestCustomFieldNames:
+    def test_custom_student_id_field(self) -> None:
+        with patch("enterprise_rag_patterns.integrations.langchain._check_langchain_available"):
+            handler = FERPAComplianceCallbackHandler(
+                scope=_make_scope(),
+                student_id_field="learner_id",
+            )
+        docs = [
+            MockDocument("Record", {"learner_id": "stu_001", "institution_id": "inst_abc", "category": "academic_record"}),
+            MockDocument("Other", {"learner_id": "stu_999", "institution_id": "inst_abc", "category": "academic_record"}),
+        ]
+        handler.on_retriever_end(docs)
+        assert len(docs) == 1
+        assert docs[0].metadata["learner_id"] == "stu_001"
+
+    def test_custom_category_field(self) -> None:
+        with patch("enterprise_rag_patterns.integrations.langchain._check_langchain_available"):
+            handler = FERPAComplianceCallbackHandler(
+                scope=_make_scope(categories={RecordCategory.ACADEMIC_RECORD}),
+                category_field="doc_type",
+            )
+        docs = [
+            MockDocument("Academic", {"student_id": "stu_001", "institution_id": "inst_abc", "doc_type": "academic_record"}),
+            MockDocument("Health", {"student_id": "stu_001", "institution_id": "inst_abc", "doc_type": "health_record"}),
+        ]
+        handler.on_retriever_end(docs)
+        assert len(docs) == 1
+        assert docs[0].metadata["doc_type"] == "academic_record"
+
+
+# ---------------------------------------------------------------------------
+# ImportError path
+# ---------------------------------------------------------------------------
+
+
+def test_raises_import_error_when_langchain_missing() -> None:
+    """Handler __init__ must raise ImportError with install instructions if langchain-core absent."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def mock_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "langchain_core.callbacks":
+            raise ImportError("No module named 'langchain_core'")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=mock_import):
+        with pytest.raises(ImportError, match="langchain-core"):
+            FERPAComplianceCallbackHandler(scope=_make_scope())

--- a/tests/test_langchain_integration.py
+++ b/tests/test_langchain_integration.py
@@ -21,7 +21,6 @@ from enterprise_rag_patterns.compliance import (
 )
 from enterprise_rag_patterns.integrations.langchain import FERPAComplianceCallbackHandler
 
-
 # ---------------------------------------------------------------------------
 # Stub: duck-typed LangChain Document (no SDK needed)
 # ---------------------------------------------------------------------------
@@ -63,9 +62,7 @@ def _make_handler(
     audit_sink: Any = None,
 ) -> FERPAComplianceCallbackHandler:
     """Construct handler with langchain-core import check patched out."""
-    with patch(
-        "enterprise_rag_patterns.integrations.langchain._check_langchain_available"
-    ):
+    with patch("enterprise_rag_patterns.integrations.langchain._check_langchain_available"):
         return FERPAComplianceCallbackHandler(
             scope=scope or _make_scope(),
             raise_on_violation=raise_on_violation,
@@ -93,8 +90,12 @@ class TestIdentityFiltering:
     def test_blocks_cross_student_documents(self) -> None:
         handler = _make_handler()
         docs = [
-            MockDocument("Other student", {"student_id": "stu_999", "institution_id": "inst_abc", "category": "academic_record"}),
-            MockDocument("Own record", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "academic_record"}),
+            MockDocument(
+                "Other student", {"student_id": "stu_999", "institution_id": "inst_abc", "category": "academic_record"}
+            ),
+            MockDocument(
+                "Own record", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "academic_record"}
+            ),
         ]
         handler.on_retriever_end(docs)
         assert len(docs) == 1
@@ -103,7 +104,9 @@ class TestIdentityFiltering:
     def test_blocks_cross_institution_documents(self) -> None:
         handler = _make_handler()
         docs = [
-            MockDocument("Other inst", {"student_id": "stu_001", "institution_id": "inst_xyz", "category": "academic_record"}),
+            MockDocument(
+                "Other inst", {"student_id": "stu_001", "institution_id": "inst_xyz", "category": "academic_record"}
+            ),
         ]
         handler.on_retriever_end(docs)
         assert len(docs) == 0
@@ -125,8 +128,12 @@ class TestIdentityFiltering:
         handler = _make_handler()
         docs = [
             MockDocument("Own", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "academic_record"}),
-            MockDocument("Other student", {"student_id": "stu_002", "institution_id": "inst_abc", "category": "academic_record"}),
-            MockDocument("Other inst", {"student_id": "stu_001", "institution_id": "inst_xyz", "category": "academic_record"}),
+            MockDocument(
+                "Other student", {"student_id": "stu_002", "institution_id": "inst_abc", "category": "academic_record"}
+            ),
+            MockDocument(
+                "Other inst", {"student_id": "stu_001", "institution_id": "inst_xyz", "category": "academic_record"}
+            ),
             MockDocument("Shared KB", {}),
         ]
         handler.on_retriever_end(docs)
@@ -145,7 +152,9 @@ class TestCategoryFiltering:
     def test_blocks_unauthorized_category(self) -> None:
         handler = _make_handler(scope=_make_scope(categories={RecordCategory.ACADEMIC_RECORD}))
         docs = [
-            MockDocument("Health record", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "health_record"}),
+            MockDocument(
+                "Health record", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "health_record"}
+            ),
         ]
         handler.on_retriever_end(docs)
         assert len(docs) == 0
@@ -153,7 +162,9 @@ class TestCategoryFiltering:
     def test_allows_authorized_category(self) -> None:
         handler = _make_handler(scope=_make_scope(categories={RecordCategory.ACADEMIC_RECORD}))
         docs = [
-            MockDocument("Transcript", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "academic_record"}),
+            MockDocument(
+                "Transcript", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "academic_record"}
+            ),
         ]
         handler.on_retriever_end(docs)
         assert len(docs) == 1
@@ -162,7 +173,9 @@ class TestCategoryFiltering:
         """FERPA: directory_information is always permitted regardless of scope."""
         handler = _make_handler(scope=_make_scope(categories={RecordCategory.ACADEMIC_RECORD}))
         docs = [
-            MockDocument("Dir info", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "directory_information"}),
+            MockDocument(
+                "Dir info", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "directory_information"}
+            ),
         ]
         handler.on_retriever_end(docs)
         assert len(docs) == 1
@@ -170,9 +183,16 @@ class TestCategoryFiltering:
     def test_blocks_multiple_unauthorized_categories(self) -> None:
         handler = _make_handler(scope=_make_scope(categories={RecordCategory.ACADEMIC_RECORD}))
         docs = [
-            MockDocument("Health", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "health_record"}),
-            MockDocument("Disciplinary", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "disciplinary_record"}),
-            MockDocument("Academic", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "academic_record"}),
+            MockDocument(
+                "Health", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "health_record"}
+            ),
+            MockDocument(
+                "Disciplinary",
+                {"student_id": "stu_001", "institution_id": "inst_abc", "category": "disciplinary_record"},
+            ),
+            MockDocument(
+                "Academic", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "academic_record"}
+            ),
         ]
         handler.on_retriever_end(docs)
         assert len(docs) == 1
@@ -188,7 +208,9 @@ class TestRaiseOnViolation:
     def test_raises_when_unauthorized_document_blocked(self) -> None:
         handler = _make_handler(raise_on_violation=True)
         docs = [
-            MockDocument("Other student", {"student_id": "stu_999", "institution_id": "inst_abc", "category": "academic_record"}),
+            MockDocument(
+                "Other student", {"student_id": "stu_999", "institution_id": "inst_abc", "category": "academic_record"}
+            ),
         ]
         with pytest.raises(ValueError, match="FERPA violation"):
             handler.on_retriever_end(docs)
@@ -205,7 +227,9 @@ class TestRaiseOnViolation:
     def test_does_not_raise_in_default_mode(self) -> None:
         handler = _make_handler(raise_on_violation=False)
         docs = [
-            MockDocument("Other", {"student_id": "stu_999", "institution_id": "inst_abc", "category": "academic_record"}),
+            MockDocument(
+                "Other", {"student_id": "stu_999", "institution_id": "inst_abc", "category": "academic_record"}
+            ),
         ]
         # Should silently drop, not raise
         handler.on_retriever_end(docs)
@@ -222,7 +246,9 @@ class TestAuditSink:
         audit_log: list[AuditRecord] = []
         handler = _make_handler(audit_sink=audit_log.append)
         docs = [
-            MockDocument("Transcript", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "academic_record"}),
+            MockDocument(
+                "Transcript", {"student_id": "stu_001", "institution_id": "inst_abc", "category": "academic_record"}
+            ),
         ]
         handler.on_retriever_end(docs)
         assert len(audit_log) == 1
@@ -244,7 +270,9 @@ class TestAuditSink:
         audit_log: list[AuditRecord] = []
         handler = _make_handler(audit_sink=audit_log.append)
         docs = [
-            MockDocument("Other", {"student_id": "stu_999", "institution_id": "inst_abc", "category": "academic_record"}),
+            MockDocument(
+                "Other", {"student_id": "stu_999", "institution_id": "inst_abc", "category": "academic_record"}
+            ),
         ]
         handler.on_retriever_end(docs)
         assert len(audit_log) == 0
@@ -299,8 +327,12 @@ class TestCustomFieldNames:
                 student_id_field="learner_id",
             )
         docs = [
-            MockDocument("Record", {"learner_id": "stu_001", "institution_id": "inst_abc", "category": "academic_record"}),
-            MockDocument("Other", {"learner_id": "stu_999", "institution_id": "inst_abc", "category": "academic_record"}),
+            MockDocument(
+                "Record", {"learner_id": "stu_001", "institution_id": "inst_abc", "category": "academic_record"}
+            ),
+            MockDocument(
+                "Other", {"learner_id": "stu_999", "institution_id": "inst_abc", "category": "academic_record"}
+            ),
         ]
         handler.on_retriever_end(docs)
         assert len(docs) == 1
@@ -313,8 +345,12 @@ class TestCustomFieldNames:
                 category_field="doc_type",
             )
         docs = [
-            MockDocument("Academic", {"student_id": "stu_001", "institution_id": "inst_abc", "doc_type": "academic_record"}),
-            MockDocument("Health", {"student_id": "stu_001", "institution_id": "inst_abc", "doc_type": "health_record"}),
+            MockDocument(
+                "Academic", {"student_id": "stu_001", "institution_id": "inst_abc", "doc_type": "academic_record"}
+            ),
+            MockDocument(
+                "Health", {"student_id": "stu_001", "institution_id": "inst_abc", "doc_type": "health_record"}
+            ),
         ]
         handler.on_retriever_end(docs)
         assert len(docs) == 1


### PR DESCRIPTION
## Summary

- Adds `FERPAComplianceCallbackHandler` in `src/enterprise_rag_patterns/integrations/langchain.py` — a duck-typed LangChain `BaseCallbackHandler` that intercepts `on_retriever_end` and enforces two-layer FERPA filtering (identity pre-filter + category authorization) before documents reach the LLM context window
- Updates `integrations/__init__.py` to export `FERPAComplianceCallbackHandler` alongside the existing Haystack and LlamaIndex adapters
- Adds `langchain = ["langchain-core>=0.3.0"]` to `[project.optional-dependencies]` in `pyproject.toml`
- Adds `tests/test_langchain_integration.py` — 27 tests covering identity filtering, category filtering, `raise_on_violation` mode, audit sink integration, no-op handlers, custom field names, and the ImportError path (all passing, no langchain-core required)
- Adds `examples/ferpa_langchain_rag.py` — self-contained runnable example demonstrating the full integration pattern with mock stubs

## Regulatory basis
- 34 CFR § 99.31(a)(1) — access control (legitimate educational interest)
- 34 CFR § 99.32 — record of disclosures (audit log requirement)

## Test plan
- [ ] `pip install -e ".[test]" && python -m pytest tests/test_langchain_integration.py -v` — 27 tests pass without langchain-core
- [ ] `python -m pytest tests/ -q` — full suite (118 tests) passes unchanged
- [ ] `python examples/ferpa_langchain_rag.py` — example runs end-to-end, asserts 3 authorized docs and 1 audit record

🤖 Generated with [Claude Code](https://claude.com/claude-code)